### PR TITLE
create environment.yml for env

### DIFF
--- a/src/pack.rs
+++ b/src/pack.rs
@@ -241,12 +241,10 @@ async fn create_environment_file(
 
     for package in packages {
         let match_spec_str = format!(
-            "./{}/{}::{}={}={}",
-            CHANNEL_DIRECTORY_NAME,
-            package.subdir,
+            "{}={}={}",
             package.name.as_normalized(),
             package.version,
-            package.build
+            package.build,
         );
 
         environment.push_str(&format!("  - {}\n", match_spec_str));


### PR DESCRIPTION
To my surprise,

```yaml
name: my_super_duper_env
channels:
  - ./channel
  - nodefaults
dependencies:
  - brotli
```

actually works correctly with `conda` and `mamba`. However, when I include the matchspec

`./channel/noarch::myPackage`, only mamba/micromamba correctly resolves the channel name to a local directory. `conda` attempts to find `channel` on `anaconda.org`. By omitting the channel name and the subdir, we get a `conda` and `mamba` compatible `environment.yml` file that will create an environment with precisely all packages from the pack.