### PR TITLE
manifest_path should not be required

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ enum Commands {
         auth_file: Option<PathBuf>,
 
         /// The path to 'pixi.toml' or 'pyproject.toml'
-        #[arg(required = true, default_value = cwd().join("pixi.toml").into_os_string())]
+        #[arg(default_value = cwd().join("pixi.toml").into_os_string())]
         manifest_path: PathBuf,
 
         /// Output file to write the pack to


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

manifest_path should be a positional arg, but not required (default is CWD/pixi.toml)

# Changes

Drop `required = True`

<!-- What changes have been performed? -->
