### PR TITLE
chore: Remove zstd compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,13 +113,18 @@ $RECYCLE.BIN/
 *.egg-info
 
 # pixi-pack
-environment.tar.zstd
-environment.tar
-environment
-env/
-unpack/
-cache/
 activate.*
+cache/
+channel/
+env/
+environment.yml
+environment
+environment.tar
+environment.tar.zst
+environment.tar.zstd
+pixi-pack.json
+unpack/
+
 # pixi environments
 .pixi
 *.egg-info

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,93 +1,64 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug unit tests in library 'pixi-pack'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--lib",
-                    "--package=pixi-pack"
-                ],
-                "filter": {
-                    "name": "pixi-pack",
-                    "kind": "lib"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug 'pixi-pack pack'",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=pixi-pack",
-                    "--package=pixi-pack"
-                ],
-                "filter": {
-                    "name": "pixi-pack",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "pack",
-                "-e",
-                "default",
-                "-p",
-                "osx-arm64",
-                "-m",
-                "test/pixi.toml"
-            ],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug 'pixi-pack unpack'",
-            "cargo": {
-                "args": [
-                    "build",
-                    "--bin=pixi-pack",
-                    "--package=pixi-pack"
-                ],
-                "filter": {
-                    "name": "pixi-pack",
-                    "kind": "bin"
-                }
-            },
-            "args": [
-                "unpack",
-                "environment.tar.zstd"
-            ],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug unit tests in executable 'pixi-pack'",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--bin=pixi-pack",
-                    "--package=pixi-pack"
-                ],
-                "filter": {
-                    "name": "pixi-pack",
-                    "kind": "bin"
-                }
-            },
-            "args": [],
-            "cwd": "${workspaceFolder}"
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in library 'pixi-pack'",
+      "cargo": {
+        "args": ["test", "--no-run", "--lib", "--package=pixi-pack"],
+        "filter": {
+          "name": "pixi-pack",
+          "kind": "lib"
         }
-    ]
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug 'pixi-pack pack'",
+      "cargo": {
+        "args": ["build", "--bin=pixi-pack", "--package=pixi-pack"],
+        "filter": {
+          "name": "pixi-pack",
+          "kind": "bin"
+        }
+      },
+      "args": ["pack", "-e", "default", "-p", "osx-arm64", "-m", "test/pixi.toml"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug 'pixi-pack unpack'",
+      "cargo": {
+        "args": ["build", "--bin=pixi-pack", "--package=pixi-pack"],
+        "filter": {
+          "name": "pixi-pack",
+          "kind": "bin"
+        }
+      },
+      "args": ["unpack", "environment.tar"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in executable 'pixi-pack'",
+      "cargo": {
+        "args": ["test", "--no-run", "--bin=pixi-pack", "--package=pixi-pack"],
+        "filter": {
+          "name": "pixi-pack",
+          "kind": "bin"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,8 +152,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -2207,7 +2205,6 @@ name = "pixi-pack"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "async-compression",
  "async-std",
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ tracing-subscriber = { version = "0.3.18", features = [
 ] }
 tracing-log = "0.2"
 url = "2.5.0"
-async-compression = { version = "0.4.11", features = ["tokio", "zstd"] }
 fxhash = "0.2.1"
 tempfile = "3.10.1"
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Starting with a [pixi](https://pixi.sh) lockfile `pixi.lock`, you can create a p
 This environment can be unpacked on any system using `pixi-pack` to recreate the original environment.
 
 In contrast to [`conda-pack`](https://conda.github.io/conda-pack/), `pixi-pack` does not require the original conda environment to be present on the system for packing.
-Instead, it uses the lockfile to download the required packages and puts them into a `.tar.zstd` archive.
+Instead, it uses the lockfile to download the required packages and puts them into a `.tar` archive.
 This archive can then be shared with others and installed using `pixi-pack unpack` to recreate the original environment.
 
 The original motivation behind `pixi-pack` was to create a `conda-pack` alternative that does not have the same reproducibility issues as `conda-pack`.
@@ -43,16 +43,16 @@ Or by downloading our pre-built binaries from the [releases page](https://github
 
 ### `pixi-pack pack`: Packing an environment
 
-With `pixi-pack pack`, you can pack a conda environment into a `environment.tar.zstd` file:
+With `pixi-pack pack`, you can pack a conda environment into a `environment.tar` file:
 
 ```bash
 pixi-pack pack --manifest-file pixi.toml --environment prod --platform linux-64
 ```
 
-This will create a `environment.tar.zstd` file that contains all conda packages required to create the environment.
+This will create a `environment.tar` file that contains all conda packages required to create the environment.
 
 ```
-# environment.tar.zstd
+# environment.tar
 | pixi-pack.json
 | environment.yml
 | channel
@@ -68,17 +68,17 @@ This will create a `environment.tar.zstd` file that contains all conda packages 
 
 ### `pixi-pack unpack`: Unpacking an environment
 
-With `pixi-pack unpack environment.tar.zstd`, you can unpack the environment on your target system.
+With `pixi-pack unpack environment.tar`, you can unpack the environment on your target system.
 This will create a new conda environment in `./env` that contains all packages specified in your `pixi.toml`.
 It also creates an `activate.sh` (or `activate.bat` on Windows) file that lets you activate the environment
 without needing to have `conda` or `micromamba` installed.
 
 ```bash
-$ pixi-pack unpack environment.tar.zstd
+$ pixi-pack unpack environment.tar
 $ ls
 env/
 activate.sh
-environment.tar.zstd
+environment.tar
 $ cat activate.sh
 export PATH="/home/user/project/env/bin:..."
 export CONDA_PREFIX="/home/user/project/env"
@@ -109,12 +109,12 @@ This can be particularly useful if you build the project itself and want to incl
 ### Unpacking without `pixi-pack`
 
 If you don't have `pixi-pack` available on your target system, you can still install the environment if you have `conda` or `micromamba` available.
-Just decompress the `environment.tar.zstd`, then you have a local channel on your system where all necessary packages are available.
+Just unarchive the `environment.tar`, then you have a local channel on your system where all necessary packages are available.
 Next to this local channel, you will find an `environment.yml` file that contains the environment specification.
 You can then install the environment using `conda` or `micromamba`:
 
 ```bash
-tar --zstd -xvf environment.tar.zstd
+tar -xvf environment.tar
 micromamba create -p ./env --file environment.yml
 # or
 conda env create -p ./env --file environment.yml

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,8 @@ enum Commands {
         #[arg(default_value = cwd().join("pixi.toml").into_os_string())]
         manifest_path: PathBuf,
 
-        /// Output file to write the pack to
-        #[arg(short, long, default_value = cwd().join("environment.tar.zstd").into_os_string())]
+        /// Output file to write the pack to (will be an archive)
+        #[arg(short, long, default_value = cwd().join("environment.tar").into_os_string())]
         output_file: PathBuf,
 
         /// Inject an additional conda package into the final prefix
@@ -114,7 +114,6 @@ async fn main() -> Result<()> {
                     version: DEFAULT_PIXI_PACK_VERSION.to_string(),
                     platform,
                 },
-                level: None,
                 injected_packages: inject,
                 ignore_pypi_errors,
             };

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
-use async_compression::tokio::bufread::ZstdDecoder;
 use futures::{
     stream::{self, StreamExt},
     TryFutureExt, TryStreamExt,
@@ -130,17 +129,14 @@ async fn collect_packages(channel_dir: &Path) -> Result<FxHashMap<String, Packag
     Ok(packages)
 }
 
-/// Unarchive a compressed tarball.
+/// Unarchive a tarball.
 pub async fn unarchive(archive_path: &Path, target_dir: &Path) -> Result<()> {
     let file = fs::File::open(archive_path)
         .await
         .map_err(|e| anyhow!("could not open archive {:#?}: {}", archive_path, e))?;
 
     let reader = tokio::io::BufReader::new(file);
-
-    let decoder = ZstdDecoder::new(reader);
-
-    let mut archive = Archive::new(decoder);
+    let mut archive = Archive::new(reader);
 
     archive
         .unpack(target_dir)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,6 @@
 
 use std::{path::PathBuf, process::Command};
 
-use async_compression::Level;
 use pixi_pack::{unarchive, PackOptions, PixiPackMetadata, UnpackOptions};
 use rattler_conda_types::Platform;
 use rattler_conda_types::RepoData;
@@ -26,12 +25,11 @@ fn options(
     #[default(Platform::current())] platform: Platform,
     #[default(None)] auth_file: Option<PathBuf>,
     #[default(PixiPackMetadata::default())] metadata: PixiPackMetadata,
-    #[default(Some(Level::Best))] level: Option<Level>,
     #[default(Some(ShellEnum::Bash(Bash)))] shell: Option<ShellEnum>,
     #[default(false)] ignore_pypi_errors: bool,
 ) -> Options {
     let output_dir = tempdir().expect("Couldn't create a temp dir for tests");
-    let pack_file = output_dir.path().join("environment.tar.zstd");
+    let pack_file = output_dir.path().join("environment.tar");
     Options {
         pack_options: PackOptions {
             environment,
@@ -40,7 +38,6 @@ fn options(
             output_file: pack_file.clone(),
             manifest_path,
             metadata,
-            level,
             injected_packages: vec![],
             ignore_pypi_errors,
         },


### PR DESCRIPTION
# Motivation

Compression has neglectable effect for the already compressed conda files:
![image](https://github.com/Quantco/pixi-pack/assets/5920521/605bceff-8e8e-4003-b4fc-8ae9c324c1bd)

# Changes

Remove zstandard compression.
If desired, users can still pick their own compression algorithm.
