### PR TITLE
chore: use cross for linux-arm builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           key: build-${{ matrix.target }}-${{ needs.metadata.outputs.optimize-build }}
 
       - name: Install cross
-        run: cargo install --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build
         run: |
-          ${{ matrix.cross && 'cross' || 'cargo' }} build --release --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{matrix.target}}
+          ${{ matrix.cross && 'cross' || 'cargo' }} build --release --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/release/pixi-pack${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }} pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
 
       - name: Upload Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
         with:
-          key: build-${{ matrix.target }}-${{ needs.metadata.outputs.optimize-build }}
+          key: build-${{ matrix.target }}-${{ needs.metadata.outputs.optimize-build }}-${{ matrix.cross}}-${{ matrix.os}}
 
       - name: Install cross
         if: matrix.cross

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,14 +69,14 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/setup-cross-toolchain-action@v1
-        with:
-          target: ${{ matrix.target }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
         with:
           key: build-${{ matrix.target }}-${{ needs.metadata.outputs.optimize-build }}
+
+      - name: Install cross
+        run: cargo install --git https://github.com/cross-rs/cross
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,11 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest-arm-4core
+            os: ubuntu-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest-arm-4core
+            os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
           - target: aarch64-apple-darwin
@@ -80,7 +80,7 @@ jobs:
 
       - name: Build
         run: |
-          pixi run build --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }}
+          pixi run cross-build --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{matrix.target}}
           mv target/release/pixi-pack${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }} pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
 
       - name: Upload Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
             cross: true
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            cross: false
+            cross: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             cross: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
@@ -89,7 +91,7 @@ jobs:
       - name: Build
         run: |
           ${{ matrix.cross && 'cross' || 'cargo' }} build --release --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{matrix.target}}
-          mv target/release/pixi-pack${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }} pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
+          mv target/${{ matrix.target }}/release/pixi-pack${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }} pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
         with:
-          key: build-${{ matrix.target }}-${{ needs.metadata.outputs.optimize-build }}-${{ matrix.cross}}-${{ matrix.os}}
+          key: build-${{ matrix.target }}-${{ needs.metadata.outputs.optimize-build }}-${{ matrix.cross }}-${{ matrix.os }}
 
       - name: Install cross
         if: matrix.cross

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           version-extraction-override: 'regex:version = "(.*)"'
 
   build:
-    name: Build Binary
+    name: Build Binary (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     needs: [metadata]
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,18 +33,25 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            cross: false
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
+            cross: true
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            cross: false
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+            cross: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            cross: false
           - target: aarch64-apple-darwin
             os: macos-latest
+            cross: false
           - target: x86_64-apple-darwin
             os: macos-13
+            cross: false
     env:
       # These are some environment variables that configure the build so that the binary size is reduced.
       # Inspiration was taken from this blog: https://arusahni.net/blog/2020/03/optimizing-rust-binary-size.html
@@ -76,11 +83,12 @@ jobs:
           key: build-${{ matrix.target }}-${{ needs.metadata.outputs.optimize-build }}
 
       - name: Install cross
+        if: matrix.cross
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build
         run: |
-          cross build --release --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{matrix.target}}
+          ${{ matrix.cross && 'cross' || 'cargo' }} build --release --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{matrix.target}}
           mv target/release/pixi-pack${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }} pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
 
       - name: Upload Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,8 @@ jobs:
 
       # Optimize the binary for size. This reduces the filesize at the cost of a slower binary.
       CARGO_PROFILE_OPT_LEVEL: ${{ needs.metadata.outputs.optimize-build && 's' || '0' }}
+
+      CROSS_CUSTOM_TOOLCHAIN: 1
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,16 +64,14 @@ jobs:
 
       # Optimize the binary for size. This reduces the filesize at the cost of a slower binary.
       CARGO_PROFILE_OPT_LEVEL: ${{ needs.metadata.outputs.optimize-build && 's' || '0' }}
-
-      CROSS_CUSTOM_TOOLCHAIN: 1
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: Set up pixi
-        uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
-          activate-environment: true
+          target: ${{ matrix.target }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
@@ -82,7 +80,7 @@ jobs:
 
       - name: Build
         run: |
-          pixi run cross-build --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{matrix.target}}
+          cross build --release --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{matrix.target}}
           mv target/release/pixi-pack${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }} pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
 
       - name: Upload Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            cross: false
+            cross: true
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             cross: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 on:
-  push:
-    branches:
-      - main
+  merge_group:
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: [push]
+on:
+  pull_request:
+  merge_group:
 
 # Automatically stop old builds on the same branch/PR
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - ubuntu-latest-arm-4core
           - windows-latest
           - macos-latest
           - macos-13

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,11 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH",
+]
+
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH",
+]

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,6 +4,8 @@ channels = ["conda-forge"]
 platforms = ["osx-arm64", "osx-64", "linux-64", "linux-aarch64", "win-64"]
 
 [tasks]
+install-cross = "cargo install cross --git https://github.com/cross-rs/cross"
+cross-build = { cmd = "cross build --release", depends-on = ["install-cross"] }
 build = "cargo build --release"
 test = "cargo test"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,8 +4,6 @@ channels = ["conda-forge"]
 platforms = ["osx-arm64", "osx-64", "linux-64", "linux-aarch64", "win-64"]
 
 [tasks]
-install-cross = "cargo install cross --git https://github.com/cross-rs/cross"
-cross-build = { cmd = "cross build --release", depends-on = ["install-cross"] }
 build = "cargo build --release"
 test = "cargo test"
 


### PR DESCRIPTION
# Motivation

ubuntu-arm runners are not available in public repos

# Changes

<!-- What changes have been performed? -->
Use cargo-cross to cross-compile for linux-aarch
