### PR TITLE
fix: Set timestamps correctly inside pack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033b337d725b97690d86893f9de22b67b80dcc4e9ad815f348254c38119db8fb"
+dependencies = [
+ "io-lifetimes 2.0.3",
+ "rustix 0.38.34",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,6 +1661,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a611371471e98973dbcab4e0ec66c31a10bc356eeb4d54a0e05eac8158fe38c"
 
 [[package]]
 name = "ipnet"
@@ -2375,6 +2392,7 @@ dependencies = [
  "async-std",
  "clap",
  "clap-verbosity-flag",
+ "fs-set-times",
  "futures",
  "fxhash",
  "indicatif",
@@ -2400,6 +2418,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -3145,7 +3164,7 @@ checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 1.0.11",
  "libc",
  "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,6 +2367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,4 @@ fs-set-times = "0.20.1"
 [dev-dependencies]
 async-std = "1.13.0"
 rstest = "0.23.0"
+sha2 = "0.10.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ tracing-log = "0.2"
 url = "2.5.2"
 fxhash = "0.2.1"
 tempfile = "3.10.1"
+walkdir = "2.5.0"
+fs-set-times = "0.20.1"
 
 [dev-dependencies]
 async-std = "1.12.0"

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -175,7 +175,6 @@ pub async fn pack(options: PackOptions) -> Result<()> {
         .follow_links(true)
         .into_iter()
         .filter_map(|e| e.ok())
-        .filter(|e| e.path() != output_folder.path())
     {
         match entry.path().extension().and_then(|e| e.to_str()) {
             Some("bz2") | Some("conda") => continue,

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -179,7 +179,7 @@ pub async fn pack(options: PackOptions) -> Result<()> {
         .filter(|e| e.path() != output_folder.path())
     {
         match entry.path().extension().and_then(|e| e.to_str()) {
-            Some("tar.bz2") | Some("conda") => continue,
+            Some("bz2") | Some("conda") => continue,
             _ => {
                 set_default_file_times(entry.path()).map_err(|e| {
                     anyhow!(

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     fs::FileTimes,
-    os::macos::fs::FileTimesExt,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -270,8 +269,7 @@ async fn download_package(
         .ok_or_else(|| anyhow!("could not read package timestamp"))?;
     let file_times = FileTimes::new()
         .set_modified(package_timestamp.into())
-        .set_accessed(package_timestamp.into())
-        .set_created(package_timestamp.into());
+        .set_accessed(package_timestamp.into());
 
     // Make sure to write all data and metadata to disk before modifying timestamp.
     dest.sync_all().await?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use std::{path::Path, time::Duration};
 
+use fs_set_times::{set_times, SystemTimeSpec};
 use indicatif::{ProgressBar, ProgressStyle};
 
 /// Progress reporter that wraps a progress bar with default styles.
@@ -29,4 +30,25 @@ pub fn get_size<P: AsRef<Path>>(path: P) -> std::io::Result<u64> {
         }
     }
     Ok(size)
+}
+
+/// Set the modified, accessed, created time for a file.
+pub fn set_default_file_times<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
+    // TODO: This will only change the times for files not for directories.
+    // let file_default_time = std::time::SystemTime::UNIX_EPOCH;
+    // let file_times = FileTimes::new()
+    //     .set_accessed(file_default_time)
+    //     .set_modified(file_default_time);
+    // let dest = std::fs::File::open(path)?;
+    // dest.set_times(file_times)?;
+    println!("Changing times for {:?}", path.as_ref());
+    // TODO: Supposedly this external crate also supports changing mtime, atime for directories
+    // but it doesn't fix it.
+    set_times(
+        path,
+        Some(SystemTimeSpec::Absolute(std::time::SystemTime::UNIX_EPOCH)),
+        Some(SystemTimeSpec::Absolute(std::time::SystemTime::UNIX_EPOCH)),
+    )?;
+
+    Ok(())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,21 +34,11 @@ pub fn get_size<P: AsRef<Path>>(path: P) -> std::io::Result<u64> {
 
 /// Set the modified, accessed, created time for a file.
 pub fn set_default_file_times<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
-    // TODO: This will only change the times for files not for directories.
-    // let file_default_time = std::time::SystemTime::UNIX_EPOCH;
-    // let file_times = FileTimes::new()
-    //     .set_accessed(file_default_time)
-    //     .set_modified(file_default_time);
-    // let dest = std::fs::File::open(path)?;
-    // dest.set_times(file_times)?;
-    println!("Changing times for {:?}", path.as_ref());
-    // TODO: Supposedly this external crate also supports changing mtime, atime for directories
-    // but it doesn't fix it.
+    tracing::debug!("Changing times for {:?}", path.as_ref());
     set_times(
         path,
         Some(SystemTimeSpec::Absolute(std::time::SystemTime::UNIX_EPOCH)),
         Some(SystemTimeSpec::Absolute(std::time::SystemTime::UNIX_EPOCH)),
     )?;
-
     Ok(())
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
+use sha2::{Digest, Sha256};
+use std::{fs, io};
 use std::{path::PathBuf, process::Command};
 
 use pixi_pack::{unarchive, PackOptions, PixiPackMetadata, UnpackOptions};
@@ -267,4 +269,35 @@ async fn test_pypi_ignore(
     pack_options.ignore_pypi_errors = ignore_pypi_errors;
     let pack_result = pixi_pack::pack(pack_options).await;
     assert_eq!(pack_result.is_err(), should_fail);
+}
+
+fn sha256_digest_bytes(path: &PathBuf) -> String {
+    let mut hasher = Sha256::new();
+    let mut file = fs::File::open(path).unwrap();
+    let _bytes_written = io::copy(&mut file, &mut hasher).unwrap();
+    let digest = hasher.finalize();
+    format!("{:X}", digest)
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_reproducible_shasum(options: Options) {
+    let mut pack_options = options.pack_options;
+    let output_file1 = options.output_dir.path().join("environment1.tar");
+    let output_file2 = options.output_dir.path().join("environment2.tar");
+
+    // First pack.
+    pack_options.output_file = output_file1.clone();
+    let pack_result = pixi_pack::pack(pack_options.clone()).await;
+    assert!(pack_result.is_ok(), "{:?}", pack_result);
+
+    // Second pack.
+    pack_options.output_file = output_file2.clone();
+    let pack_result = pixi_pack::pack(pack_options).await;
+    assert!(pack_result.is_ok(), "{:?}", pack_result);
+
+    assert_eq!(
+        sha256_digest_bytes(&output_file1),
+        sha256_digest_bytes(&output_file2)
+    );
 }


### PR DESCRIPTION
# Motivation

Closes #41.

# Changes

* Update timestamp of conda packages to timestamp from `pixi.lock`
* Update timestamp of other files in archive to UNIX epoch
