### PR TITLE
fix: Fix leaking package cache directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-pack"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixi-pack"
 description = "A command line tool to pack and unpack conda environments for easy sharing"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [features]

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -163,13 +163,14 @@ async fn create_prefix(channel_dir: &Path, target_prefix: &Path) -> Result<()> {
         .await
         .map_err(|e| anyhow!("could not collect packages: {}", e))?;
 
-    let cache_dir = tempfile::tempdir()
-        .map_err(|e| anyhow!("could not create temporary directory: {}", e))?
-        .into_path();
+    let tmp_dir =
+        tempfile::tempdir().map_err(|e| anyhow!("Could not create temporary directory: {}", e))?;
+    let cache_dir = tmp_dir.path();
 
     eprintln!(
-        "⏳ Extracting and installing {} packages...",
-        packages.len()
+        "⏳ Extracting and installing {} packages to {}...",
+        packages.len(),
+        cache_dir.display()
     );
     let reporter = ProgressReporter::new(packages.len() as u64);
 

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -39,7 +39,6 @@ pub async fn unpack(options: UnpackOptions) -> Result<()> {
     let tmp_dir =
         tempfile::tempdir().map_err(|e| anyhow!("Could not create temporary directory: {}", e))?;
     let unpack_dir = tmp_dir.path();
-    let channel_directory = unpack_dir.join(CHANNEL_DIRECTORY_NAME);
 
     tracing::info!("Unarchiving pack to {}", unpack_dir.display());
     unarchive(&options.pack_file, unpack_dir)
@@ -51,7 +50,9 @@ pub async fn unpack(options: UnpackOptions) -> Result<()> {
     let target_prefix = options.output_directory.join("env");
 
     tracing::info!("Creating prefix at {}", target_prefix.display());
-    create_prefix(&channel_directory, &target_prefix)
+    let channel_directory = unpack_dir.join(CHANNEL_DIRECTORY_NAME);
+    let cache_dir = unpack_dir.join("cache");
+    create_prefix(&channel_directory, &target_prefix, &cache_dir)
         .await
         .map_err(|e| anyhow!("Could not create prefix: {}", e))?;
 
@@ -72,6 +73,10 @@ pub async fn unpack(options: UnpackOptions) -> Result<()> {
         "💫 Finished unpacking to {}.",
         options.output_directory.display()
     );
+
+    tmp_dir
+        .close()
+        .map_err(|e| anyhow!("Could not remove temporary directory: {}", e))?;
 
     Ok(())
 }
@@ -158,14 +163,10 @@ pub async fn unarchive(archive_path: &Path, target_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-async fn create_prefix(channel_dir: &Path, target_prefix: &Path) -> Result<()> {
+async fn create_prefix(channel_dir: &Path, target_prefix: &Path, cache_dir: &Path) -> Result<()> {
     let packages = collect_packages(channel_dir)
         .await
         .map_err(|e| anyhow!("could not collect packages: {}", e))?;
-
-    let tmp_dir =
-        tempfile::tempdir().map_err(|e| anyhow!("Could not create temporary directory: {}", e))?;
-    let cache_dir = tmp_dir.path();
 
     eprintln!(
         "⏳ Extracting and installing {} packages to {}...",


### PR DESCRIPTION
# Motivation

The rattler package cache temporary directory leaks.

# Changes

Similar to #42, fix the leaking temporary directory.
