### PR TITLE
ci: Remove merge queue from workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
 name: Build
 on:
-  merge_group:
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   metadata:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 on:
   pull_request:
-  merge_group:
+  push:
+    branches: [main]
 
 # Automatically stop old builds on the same branch/PR
 concurrency:


### PR DESCRIPTION
# Motivation

We don't require the merge queue anymore.

# Changes

Remove merge queue.
