### PR TITLE
fix: Use default when no timestamp is provided in package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-pack"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixi-pack"
 description = "A command line tool to pack and unpack conda environments for easy sharing"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [features]

--- a/examples/no-timestamp/pixi.lock
+++ b/examples/no-timestamp/pixi.lock
@@ -1,0 +1,21 @@
+version: 5
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mpi-1.0-openmpi.tar.bz2
+packages:
+- kind: conda
+  name: mpi
+  version: '1.0'
+  build: openmpi
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mpi-1.0-openmpi.tar.bz2
+  sha256: 1326b28195e8808cebc18a593f84c5cbd606826a150dd7e0365f11b86238b5df
+  md5: 8c3bc725bf4d10fc6e56031f7543771f
+  arch: x86_64
+  platform: osx
+  license: BSD 3-clause
+  size: 4394

--- a/examples/no-timestamp/pixi.toml
+++ b/examples/no-timestamp/pixi.toml
@@ -1,0 +1,7 @@
+[project]
+channels = ["conda-forge"]
+name = "no-timestamp"
+platforms = ["osx-64"]
+
+[dependencies]
+mpi = { version = "1.0", build = "openmpi" }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -281,11 +281,10 @@ async fn download_package(
     let package_timestamp = package
         .package_record()
         .timestamp
-        .map_or({
+        .map(|ts| ts.into())
+        .unwrap_or_else(|| {
             tracing::error!("could not get timestamp of {:?}, using default", package.file_name());
             std::time::SystemTime::UNIX_EPOCH
-        }, |ts| {
-            ts.into()
         });
     let file_times = FileTimes::new()
         .set_modified(package_timestamp)

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -283,7 +283,10 @@ async fn download_package(
         .timestamp
         .map(|ts| ts.into())
         .unwrap_or_else(|| {
-            tracing::error!("could not get timestamp of {:?}, using default", package.file_name());
+            tracing::error!(
+                "could not get timestamp of {:?}, using default",
+                package.file_name()
+            );
             std::time::SystemTime::UNIX_EPOCH
         });
     let file_times = FileTimes::new()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -340,6 +340,17 @@ async fn test_non_authenticated(
 
 #[rstest]
 #[tokio::test]
+async fn test_no_timestamp(
+    #[with(PathBuf::from("examples/no-timestamp/pixi.toml"))] options: Options,
+) {
+    let mut pack_options = options.pack_options;
+    pack_options.platform = Platform::Osx64;
+    let pack_result = pixi_pack::pack(pack_options).await;
+    assert!(pack_result.is_ok());
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_custom_env_name(options: Options) {
     let env_name = "custom";
     let pack_options = options.pack_options;


### PR DESCRIPTION
# Motivation

#60

# Changes

Closes #60
