### PR TITLE
feat: Write pixi-pack-version to metadata file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,16 @@ pub use util::{get_size, ProgressReporter};
 pub const CHANNEL_DIRECTORY_NAME: &str = "channel";
 pub const PIXI_PACK_METADATA_PATH: &str = "pixi-pack.json";
 pub const DEFAULT_PIXI_PACK_VERSION: &str = "1";
+pub const PIXI_PACK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The metadata for a "pixi-pack".
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct PixiPackMetadata {
     /// The pack format version.
     pub version: String,
+    /// The version of pixi-pack that created the pack.
+    pub pixi_pack_version: Option<String>,
     /// The platform the pack was created for.
     pub platform: Platform,
 }
@@ -25,6 +29,7 @@ impl Default for PixiPackMetadata {
     fn default() -> Self {
         Self {
             version: DEFAULT_PIXI_PACK_VERSION.to_string(),
+            pixi_pack_version: Some(PIXI_PACK_VERSION.to_string()),
             platform: Platform::current(),
         }
     }
@@ -44,14 +49,25 @@ mod tests {
     fn test_metadata_serialization() {
         let metadata = PixiPackMetadata {
             version: DEFAULT_PIXI_PACK_VERSION.to_string(),
+            pixi_pack_version: Some(PIXI_PACK_VERSION.to_string()),
             platform: Platform::Linux64,
         };
         let result = json!(metadata).to_string();
-        assert_eq!(result, "{\"version\":\"1\",\"platform\":\"linux-64\"}");
+        assert_eq!(result, format!("{{\"version\":\"1\",\"pixi-pack-version\":\"{}\",\"platform\":\"linux-64\"}}", PIXI_PACK_VERSION));
         assert_eq!(
             serde_json::from_str::<PixiPackMetadata>(&result).unwrap(),
             metadata
         );
+    }
+
+    #[test]
+    fn test_metadata_serialization_no_pixi_pack_version() {
+        let metadata = serde_json::from_str::<PixiPackMetadata>(&json!({"version": "1", "platform": "linux-64"}).to_string());
+        assert!(metadata.is_ok());
+        let metadata = metadata.unwrap();
+        assert_eq!(metadata.version, "1");
+        assert!(metadata.pixi_pack_version.is_none());
+        assert_eq!(metadata.platform, Platform::Linux64);
     }
 
     #[rstest]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,13 @@ mod tests {
             platform: Platform::Linux64,
         };
         let result = json!(metadata).to_string();
-        assert_eq!(result, format!("{{\"version\":\"1\",\"pixi-pack-version\":\"{}\",\"platform\":\"linux-64\"}}", PIXI_PACK_VERSION));
+        assert_eq!(
+            result,
+            format!(
+                "{{\"version\":\"1\",\"pixi-pack-version\":\"{}\",\"platform\":\"linux-64\"}}",
+                PIXI_PACK_VERSION
+            )
+        );
         assert_eq!(
             serde_json::from_str::<PixiPackMetadata>(&result).unwrap(),
             metadata
@@ -62,7 +68,9 @@ mod tests {
 
     #[test]
     fn test_metadata_serialization_no_pixi_pack_version() {
-        let metadata = serde_json::from_str::<PixiPackMetadata>(&json!({"version": "1", "platform": "linux-64"}).to_string());
+        let metadata = serde_json::from_str::<PixiPackMetadata>(
+            &json!({"version": "1", "platform": "linux-64"}).to_string(),
+        );
         assert!(metadata.is_ok());
         let metadata = metadata.unwrap();
         assert_eq!(metadata.version, "1");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use rattler_conda_types::Platform;
 
 use anyhow::Result;
 use pixi_pack::{
-    pack, unpack, PackOptions, PixiPackMetadata, UnpackOptions, DEFAULT_PIXI_PACK_VERSION,
+    pack, unpack, PackOptions, PixiPackMetadata, UnpackOptions, DEFAULT_PIXI_PACK_VERSION, PIXI_PACK_VERSION,
 };
 use rattler_shell::shell::ShellEnum;
 use tracing_log::AsTrace;
@@ -117,6 +117,7 @@ async fn main() -> Result<()> {
                 manifest_path,
                 metadata: PixiPackMetadata {
                     version: DEFAULT_PIXI_PACK_VERSION.to_string(),
+                    pixi_pack_version: Some(PIXI_PACK_VERSION.to_string()),
                     platform,
                 },
                 injected_packages: inject,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use rattler_conda_types::Platform;
 
 use anyhow::Result;
 use pixi_pack::{
-    pack, unpack, PackOptions, PixiPackMetadata, UnpackOptions, DEFAULT_PIXI_PACK_VERSION, PIXI_PACK_VERSION,
+    pack, unpack, PackOptions, PixiPackMetadata, UnpackOptions, DEFAULT_PIXI_PACK_VERSION,
+    PIXI_PACK_VERSION,
 };
 use rattler_shell::shell::ShellEnum;
 use tracing_log::AsTrace;

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -23,7 +23,7 @@ use url::Url;
 
 use crate::{
     PixiPackMetadata, ProgressReporter, CHANNEL_DIRECTORY_NAME, DEFAULT_PIXI_PACK_VERSION,
-    PIXI_PACK_METADATA_PATH,
+    PIXI_PACK_METADATA_PATH, PIXI_PACK_VERSION
 };
 
 /// Options for unpacking a pixi environment.
@@ -115,6 +115,14 @@ async fn validate_metadata_file(metadata_file: PathBuf) -> Result<()> {
     }
     if metadata.platform != Platform::current() {
         anyhow::bail!("The pack was created for a different platform");
+    }
+
+    tracing::debug!("pack metadata: {:?}", metadata);
+    if metadata.pixi_pack_version != Some(PIXI_PACK_VERSION.to_string()) {
+        tracing::warn!(
+            "The pack was created with a different version of pixi-pack: {:?}",
+            metadata.pixi_pack_version
+        );
     }
 
     Ok(())
@@ -274,6 +282,8 @@ async fn create_activation_script(
 
 #[cfg(test)]
 mod tests {
+    use crate::PIXI_PACK_VERSION;
+
     use super::*;
     use rstest::*;
     use serde_json::json;
@@ -293,7 +303,7 @@ mod tests {
         #[default(Platform::current())] platform: Platform,
     ) -> NamedTempFile {
         let mut metadata_file = NamedTempFile::new().unwrap();
-        let metadata = PixiPackMetadata { version, platform };
+        let metadata = PixiPackMetadata { version, pixi_pack_version: Some(PIXI_PACK_VERSION.to_string()), platform };
         let buffer = metadata_file.as_file_mut();
         buffer
             .write_all(json!(metadata).to_string().as_bytes())

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -23,7 +23,7 @@ use url::Url;
 
 use crate::{
     PixiPackMetadata, ProgressReporter, CHANNEL_DIRECTORY_NAME, DEFAULT_PIXI_PACK_VERSION,
-    PIXI_PACK_METADATA_PATH, PIXI_PACK_VERSION
+    PIXI_PACK_METADATA_PATH, PIXI_PACK_VERSION,
 };
 
 /// Options for unpacking a pixi environment.
@@ -303,7 +303,11 @@ mod tests {
         #[default(Platform::current())] platform: Platform,
     ) -> NamedTempFile {
         let mut metadata_file = NamedTempFile::new().unwrap();
-        let metadata = PixiPackMetadata { version, pixi_pack_version: Some(PIXI_PACK_VERSION.to_string()), platform };
+        let metadata = PixiPackMetadata {
+            version,
+            pixi_pack_version: Some(PIXI_PACK_VERSION.to_string()),
+            platform,
+        };
         let buffer = metadata_file.as_file_mut();
         buffer
             .write_all(json!(metadata).to_string().as_bytes())


### PR DESCRIPTION
# Motivation

Would be nice to have some information what was being used to generate the pack file. Is also nice for reproducibility

# Changes

Write `pixi-pack-version` to `pixi-pack.json`.
If the version differs during unpack, we will print a `WARN` (only gets shown when `pixi-pack unpack -v`).

Make version `Option` to support older versions of pixi-pack.