### PR TITLE
feat: Support manifest path to project directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ enum Commands {
         #[arg(long)] // TODO: Read from environment variable?
         auth_file: Option<PathBuf>,
 
-        /// The path to 'pixi.toml' or 'pyproject.toml'
+        /// The path to `pixi.toml`, `pyproject.toml`, or the project directory
         #[arg(default_value = cwd().join("pixi.toml").into_os_string())]
         manifest_path: PathBuf,
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -557,3 +557,15 @@ async fn test_run_packed_executable(options: Options, required_fs_objects: Vec<&
     // Keep the temporary directory alive until the end of the test
     drop(temp_dir);
 }
+
+#[rstest]
+#[tokio::test]
+async fn test_manifest_path_dir(#[with(PathBuf::from("examples/simple-python"))] options: Options) {
+    let pack_options = options.pack_options;
+    let unpack_options = options.unpack_options;
+    let pack_file = unpack_options.pack_file.clone();
+
+    let pack_result = pixi_pack::pack(pack_options).await;
+    assert!(pack_result.is_ok(), "{:?}", pack_result);
+    assert!(pack_file.is_file());
+}


### PR DESCRIPTION
Allow `pixi-pack pack <manifest-path>` to accept a path to a project directory. This ports the same feature added to upstream Pixi here https://github.com/prefix-dev/pixi/pull/2716.

This also adds an additional check if the manifest path is invalid and display an error.

Fixes: https://github.com/Quantco/pixi-pack/issues/93

# Motivation
This makes pixi-pack align with how `pixi --manifest-path` works.
This fixes the bug in #93 where if a directory is used for `pixi-pack pack <directory>`, pixi pack doesn't handle it correctly and searches the directory's parent for the pixi.lock