### PR TITLE
chore: Fix pixi warning

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -8,7 +8,7 @@ build = "cargo build --release"
 test = "cargo test"
 
 [dependencies]
-rust = "1.81.0"
+rust = "==1.81.0"
 openssl = "3.*"
 pkg-config = "*"
 


### PR DESCRIPTION
# Motivation

```
 WARN Encountered ambiguous version specifier `1.81.0`, could be `1.81.0.*` but assuming you meant `==1.81.0`. In the future this will result in an error.
```
