### PR TITLE
fix: Properly convert filepath to URL during unpacking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-pack"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixi-pack"
 description = "A command line tool to pack and unpack conda environments for easy sharing"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Motivation

There's a bug in the way we convert the filepath to a `file://` URL when installing packages during unpack on Windows.

# Changes

Properly convert filepaths to URLs.