### PR TITLE
docs: Mention add_pip_as_python_dependency in compatibility mode

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,9 @@
 # Changes
 
 <!-- What changes have been performed? -->
+
+---
+
+If updating documentation:
+
+- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/advanced/production_deployment.md as well

--- a/README.md
+++ b/README.md
@@ -181,3 +181,11 @@ conda env create -p ./env --file environment.yml
 
 > [!NOTE]
 > The `environment.yml` and `repodata.json` files are only for this use case, `pixi-pack unpack` does not use them.
+
+> [!NOTE]
+> Both `conda` and `mamba` are always installing pip as a side effect when they install python, see [`conda`'s documentation](https://docs.conda.io/projects/conda/en/25.1.x/user-guide/configuration/settings.html#add-pip-as-python-dependency-add-pip-as-python-dependency).
+> This is not different from how `pixi` works and can lead to solver errors when using `pixi-pack`'s compatibility mode since `pixi-pack` doesn't include `pip` by default.
+> You can fix this issues in two ways:
+>
+> - Add `pip` to your `pixi.lock` file using `pixi add pip`.
+> - Configuring `conda` (or `mamba`) to not install `pip` by default by running `conda config --set add_pip_as_python_dependency false` (or by adding `add_pip_as_python_dependency: False` to your `~/.condarc`)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ conda env create -p ./env --file environment.yml
 > [!NOTE]
 > Both `conda` and `mamba` are always installing pip as a side effect when they install python, see [`conda`'s documentation](https://docs.conda.io/projects/conda/en/25.1.x/user-guide/configuration/settings.html#add-pip-as-python-dependency-add-pip-as-python-dependency).
 > This is not different from how `pixi` works and can lead to solver errors when using `pixi-pack`'s compatibility mode since `pixi-pack` doesn't include `pip` by default.
-> You can fix this issues in two ways:
+> You can fix this issue in two ways:
 >
 > - Add `pip` to your `pixi.lock` file using `pixi add pip`.
 > - Configuring `conda` (or `mamba`) to not install `pip` by default by running `conda config --set add_pip_as_python_dependency false` (or by adding `add_pip_as_python_dependency: False` to your `~/.condarc`)


### PR DESCRIPTION
# Motivation

closes #102 

---

If updating documentation:

- [x] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/advanced/production_deployment.md as well: https://github.com/prefix-dev/pixi/pull/3188
