### PR TITLE
feat: Implement a --use-cache flag closes #100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-pack"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixi-pack"
 description = "A command line tool to pack and unpack conda environments for easy sharing"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ This will store all downloaded packages in the specified directory and reuse the
 
 Using a cache is particularly useful when:
 
-* Creating multiple packs with overlapping dependencies
-* Working with large packages that take time to download
-* Operating in environments with limited bandwidth
-* Running CI/CD pipelines where package caching can significantly improve build times
+- Creating multiple packs with overlapping dependencies
+- Working with large packages that take time to download
+- Operating in environments with limited bandwidth
+- Running CI/CD pipelines where package caching can significantly improve build times
 
 ### Unpacking without `pixi-pack`
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,23 @@ pixi-pack pack --inject local-package-1.0.0-hbefa133_0.conda --manifest-pack pix
 This can be particularly useful if you build the project itself and want to include the built package in the environment but still want to use `pixi.lock` from the project.
 Before creating the pack, `pixi-pack` will ensure that the injected packages' dependencies and constraints are compatible with the packages in the environment.
 
+### Cache downloaded packages
+
+You can cache downloaded packages to speed up subsequent pack operations by using the `--use-cache` flag:
+
+```bash
+pixi-pack pack --use-cache ~/.pixi-pack/cache
+```
+
+This will store all downloaded packages in the specified directory and reuse them in future pack operations. The cache follows the same structure as conda channels, organizing packages by platform subdirectories (e.g., linux-64, win-64, etc.).
+
+Using a cache is particularly useful when:
+
+* Creating multiple packs with overlapping dependencies
+* Working with large packages that take time to download
+* Operating in environments with limited bandwidth
+* Running CI/CD pipelines where package caching can significantly improve build times
+
 ### Unpacking without `pixi-pack`
 
 If you don't have `pixi-pack` available on your target system, you can still install the environment if you have `conda` or `micromamba` available.

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,10 @@ enum Commands {
         #[arg(short, long)]
         output_file: Option<PathBuf>,
 
+        /// Use a cache directory for downloaded packages
+        #[arg(long)]
+        use_cache: Option<PathBuf>,
+
         /// Inject an additional conda package into the final prefix
         #[arg(short, long, num_args(0..))]
         inject: Vec<PathBuf>,
@@ -67,7 +71,6 @@ enum Commands {
         #[arg(long, default_value = "false")]
         create_executable: bool,
     },
-
     /// Unpack a pixi environment
     Unpack {
         /// Where to unpack the environment.
@@ -126,6 +129,7 @@ async fn main() -> Result<()> {
             inject,
             ignore_pypi_errors,
             create_executable,
+            use_cache,
         } => {
             let output_file =
                 output_file.unwrap_or_else(|| default_output_file(platform, create_executable));
@@ -144,11 +148,11 @@ async fn main() -> Result<()> {
                 injected_packages: inject,
                 ignore_pypi_errors,
                 create_executable,
+                cache_dir: use_cache,
             };
             tracing::debug!("Running pack command with options: {:?}", options);
             pack(options).await?
-        }
-        Commands::Unpack {
+        }        Commands::Unpack {
             output_directory,
             env_name,
             pack_file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,8 @@ async fn main() -> Result<()> {
             };
             tracing::debug!("Running pack command with options: {:?}", options);
             pack(options).await?
-        }        Commands::Unpack {
+        }
+        Commands::Unpack {
             output_directory,
             env_name,
             pack_file,

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -133,7 +133,8 @@ pub async fn pack(options: PackOptions) -> Result<()> {
             Ok(())
         })
         .await
-        .map_err(|e: anyhow::Error| anyhow!("could not download package: {}", e))?;    bar.pb.finish_and_clear();
+        .map_err(|e: anyhow::Error| anyhow!("could not download package: {}", e))?;
+    bar.pb.finish_and_clear();
 
     let mut conda_packages: Vec<(String, PackageRecord)> = Vec::new();
 
@@ -265,7 +266,9 @@ async fn download_package(
 
     // Check cache first if enabled
     if let Some(cache_dir) = cache_dir {
-        let cache_path = cache_dir.join(&package.package_record.subdir).join(file_name);
+        let cache_path = cache_dir
+            .join(&package.package_record.subdir)
+            .join(file_name);
         if cache_path.exists() {
             tracing::debug!("Using cached package from {}", cache_path.display());
             fs::copy(&cache_path, &output_path).await?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::too_many_arguments)]
 
 use sha2::{Digest, Sha256};
-use walkdir::WalkDir;
 use std::{fs, io};
 use std::{path::PathBuf, process::Command};
+use walkdir::WalkDir;
 
 use pixi_pack::{
     unarchive, PackOptions, PixiPackMetadata, UnpackOptions, DEFAULT_PIXI_PACK_VERSION,
@@ -72,7 +72,8 @@ fn options(
         },
         output_dir,
     }
-}#[fixture]
+}
+#[fixture]
 fn required_fs_objects() -> Vec<&'static str> {
     let mut required_fs_objects = vec!["conda-meta/history", "include", "share"];
     let openssl_required_file = match Platform::current() {
@@ -590,7 +591,10 @@ async fn test_package_caching(
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_file())
         .count();
-    assert!(cache_files_count > 0, "Cache should contain downloaded files");
+    assert!(
+        cache_files_count > 0,
+        "Cache should contain downloaded files"
+    );
 
     // Second pack with same cache - should use cached packages
     let temp_dir2 = tempdir().expect("Couldn't create second temp dir");
@@ -598,7 +602,7 @@ async fn test_package_caching(
     pack_options2.cache_dir = Some(cache_dir.clone());
     let output_file2 = temp_dir2.path().join("environment.tar");
     pack_options2.output_file = output_file2.clone();
-    
+
     let pack_result2 = pixi_pack::pack(pack_options2).await;
     assert!(pack_result2.is_ok(), "{:?}", pack_result2);
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::{fs, io};
 use std::{path::PathBuf, process::Command};
 use walkdir::WalkDir;
@@ -570,7 +571,6 @@ async fn test_manifest_path_dir(#[with(PathBuf::from("examples/simple-python"))]
     assert!(pack_result.is_ok(), "{:?}", pack_result);
     assert!(pack_file.is_file());
 }
-
 #[rstest]
 #[tokio::test]
 async fn test_package_caching(
@@ -585,16 +585,24 @@ async fn test_package_caching(
     let pack_result = pixi_pack::pack(pack_options).await;
     assert!(pack_result.is_ok(), "{:?}", pack_result);
 
-    // Get file count in cache after first pack
-    let cache_files_count = WalkDir::new(&cache_dir)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|e| e.file_type().is_file())
-        .count();
-    assert!(
-        cache_files_count > 0,
-        "Cache should contain downloaded files"
-    );
+    // Get files and their modification times after first pack
+    let mut initial_cache_files = HashMap::new();
+    for entry in WalkDir::new(&cache_dir) {
+        let entry = entry.unwrap();
+        if entry.file_type().is_file() {
+            let path = entry.path().to_path_buf();
+            let modified_time = fs::metadata(&path).unwrap().modified().unwrap();
+            initial_cache_files.insert(path, modified_time);
+        }
+    }
+    assert!(!initial_cache_files.is_empty(), "Cache should contain downloaded files");
+
+    // Calculate first pack's SHA256, reusing test_reproducible_shasum
+    let first_sha256 = sha256_digest_bytes(&options.pack_options.output_file);
+    insta::assert_snapshot!(format!("sha256-{}", options.pack_options.platform), &first_sha256);
+
+    // Small delay to ensure any new writes would have different timestamps
+    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
     // Second pack with same cache - should use cached packages
     let temp_dir2 = tempdir().expect("Couldn't create second temp dir");
@@ -602,22 +610,24 @@ async fn test_package_caching(
     pack_options2.cache_dir = Some(cache_dir.clone());
     let output_file2 = temp_dir2.path().join("environment.tar");
     pack_options2.output_file = output_file2.clone();
-
+    
     let pack_result2 = pixi_pack::pack(pack_options2).await;
     assert!(pack_result2.is_ok(), "{:?}", pack_result2);
 
-    // Verify cache files weren't downloaded again by checking modification times
-    let cache_files: Vec<_> = WalkDir::new(&cache_dir)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|e| e.file_type().is_file())
-        .collect();
+    // Check that cache files weren't modified
+    for (path, initial_mtime) in initial_cache_files {
+        let current_mtime = fs::metadata(&path).unwrap().modified().unwrap();
+        assert_eq!(
+            initial_mtime, 
+            current_mtime,
+            "Cache file {} was modified when it should have been reused",
+            path.display()
+        );
+    }
 
-    assert_eq!(
-        cache_files.len(),
-        cache_files_count,
-        "Cache file count should remain the same"
-    );
+    // Verify second pack produces identical output
+    let second_sha256 = sha256_digest_bytes(&output_file2);
+    assert_eq!(first_sha256, second_sha256, "Pack outputs should be identical when using cache");
 
     // Both output files should exist and be valid
     assert!(options.pack_options.output_file.exists());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -595,11 +595,17 @@ async fn test_package_caching(
             initial_cache_files.insert(path, modified_time);
         }
     }
-    assert!(!initial_cache_files.is_empty(), "Cache should contain downloaded files");
+    assert!(
+        !initial_cache_files.is_empty(),
+        "Cache should contain downloaded files"
+    );
 
     // Calculate first pack's SHA256, reusing test_reproducible_shasum
     let first_sha256 = sha256_digest_bytes(&options.pack_options.output_file);
-    insta::assert_snapshot!(format!("sha256-{}", options.pack_options.platform), &first_sha256);
+    insta::assert_snapshot!(
+        format!("sha256-{}", options.pack_options.platform),
+        &first_sha256
+    );
 
     // Small delay to ensure any new writes would have different timestamps
     tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
@@ -610,7 +616,7 @@ async fn test_package_caching(
     pack_options2.cache_dir = Some(cache_dir.clone());
     let output_file2 = temp_dir2.path().join("environment.tar");
     pack_options2.output_file = output_file2.clone();
-    
+
     let pack_result2 = pixi_pack::pack(pack_options2).await;
     assert!(pack_result2.is_ok(), "{:?}", pack_result2);
 
@@ -618,7 +624,7 @@ async fn test_package_caching(
     for (path, initial_mtime) in initial_cache_files {
         let current_mtime = fs::metadata(&path).unwrap().modified().unwrap();
         assert_eq!(
-            initial_mtime, 
+            initial_mtime,
             current_mtime,
             "Cache file {} was modified when it should have been reused",
             path.display()
@@ -627,7 +633,10 @@ async fn test_package_caching(
 
     // Verify second pack produces identical output
     let second_sha256 = sha256_digest_bytes(&output_file2);
-    assert_eq!(first_sha256, second_sha256, "Pack outputs should be identical when using cache");
+    assert_eq!(
+        first_sha256, second_sha256,
+        "Pack outputs should be identical when using cache"
+    );
 
     // Both output files should exist and be valid
     assert!(options.pack_options.output_file.exists());


### PR DESCRIPTION
# Motivation

Following up on https://github.com/Quantco/pixi-pack/issues/100 (thanks for the opportunity @pavelzw !).

As the README of this PR states, having a cache for downloads is useful when:
* Creating multiple packs with overlapping dependencies
* Working with large packages that take time to download
* Operating in environments with limited bandwidth
* Running CI/CD pipelines where package caching can significantly improve build times

`pixi`'s cache is for already-extracted packages, but here we need them un-extracted, so implementing an optional (behind the `--use-cache` flag) cache for downloads.

I have little experience in Rust[1], let me know if this is an okay implementation. 

There are some formatting changes, I used the autoformat feature from VSCode with the rust-analyzer extension.

# Changes

- Added a `--use-cache CACHE_DIR` flag.
- Added implementation for it in the download function.
- Added a test for it.
- Added README docs about it.


[1] It's so easy to jump into a project thanks to cargo! I just cloned, ran `cargo build`, then `cargo test` (which failed due to my slow internet)... and then I could just `cargo run` to test my changes (before I added my test, which I should probably have done first).

closes #100 