### PR TITLE
fix: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pavelzw @delsner @0xbe7a
+* @pavelzw @delsner


### PR DESCRIPTION
# Motivation

<img width="363" alt="image" src="https://github.com/user-attachments/assets/c346daa1-8094-4e1f-80ce-115e9d043796" />

CODEOWNERS are currently broken.

# Changes

Remove Bela from CODEOWNERS 😢  