### PR TITLE
docs: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ conda env create -p ./env --file environment.yml
 
 > [!NOTE]
 > Both `conda` and `mamba` are always installing pip as a side effect when they install python, see [`conda`'s documentation](https://docs.conda.io/projects/conda/en/25.1.x/user-guide/configuration/settings.html#add-pip-as-python-dependency-add-pip-as-python-dependency).
-> This is not different from how `pixi` works and can lead to solver errors when using `pixi-pack`'s compatibility mode since `pixi-pack` doesn't include `pip` by default.
+> This is different from how `pixi` works and can lead to solver errors when using `pixi-pack`'s compatibility mode since `pixi-pack` doesn't include `pip` by default.
 > You can fix this issue in two ways:
 >
 > - Add `pip` to your `pixi.lock` file using `pixi add pip`.


### PR DESCRIPTION
If updating documentation:

- [x] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/pixi_pack.md as well: https://github.com/prefix-dev/pixi/pull/3385
