### PR TITLE
refactor: Use error_for_status in response

### DIFF
--- a/src/pack.rs
+++ b/src/pack.rs
@@ -284,13 +284,7 @@ async fn download_package(
         UrlOrPath::Path(path) => anyhow::bail!("Path not supported: {}", path),
     };
     let mut response = client.get(url.clone()).send().await?;
-    if response.status().is_client_error() {
-        return Err(anyhow!(
-            "failed to download {}: {}",
-            url,
-            response.text().await?
-        ));
-    }
+    response = response.error_for_status()?;
 
     while let Some(chunk) = response.chunk().await? {
         dest.write_all(&chunk).await?;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -283,12 +283,9 @@ async fn download_package(
         UrlOrPath::Url(url) => url,
         UrlOrPath::Path(path) => anyhow::bail!("Path not supported: {}", path),
     };
-    let mut response = client.get(url.clone()).send().await?;
-    response = response.error_for_status()?;
 
-    while let Some(chunk) = response.chunk().await? {
-        dest.write_all(&chunk).await?;
-    }
+    let response = client.get(url.clone()).send().await?.error_for_status()?;
+    dest.write_all(response.bytes().await?.as_ref()).await?;
 
     // Save to cache if enabled
     if let Some(cache_dir) = cache_dir {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -398,7 +398,7 @@ async fn test_non_authenticated(
         .err()
         .unwrap()
         .to_string()
-        .contains("failed to download"));
+        .contains("could not download package"));
 }
 
 #[rstest]


### PR DESCRIPTION
# Motivation

Unnecessary error object when checking http response status.
