### PR TITLE
fix: Auth middleware not used in mirrored channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-pack"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixi-pack"
 description = "A command line tool to pack and unpack conda environments for easy sharing"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [features]

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -356,11 +356,11 @@ fn reqwest_client_from_options(options: &PackOptions) -> Result<ClientWithMiddle
             .build()
             .map_err(|e| anyhow!("could not create download client: {}", e))?,
     )
+    .with(mirror_middleware)
+    .with(s3_middleware)
     .with_arc(Arc::new(AuthenticationMiddleware::from_auth_storage(
         auth_storage,
     )))
-    .with(mirror_middleware)
-    .with(s3_middleware)
     .build();
     Ok(client)
 }


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

# Changes

<!-- What changes have been performed? -->

---

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/pixi_pack.md as well
