### PR TITLE
ci: Use windows arm runner during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,7 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
           - target: aarch64-pc-windows-msvc
-            os: windows-latest
-            # https://github.com/dtolnay/rust-toolchain/issues/143
-            # os: windows-11-arm
+            os: windows-11-arm
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

# Changes

<!-- What changes have been performed? -->

---

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/pixi_pack.md as well
