### PR TITLE
chore: make sure we only build one version of `version-ranges`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,20 @@ jobs:
       - name: pre-commit
         run: pixi run pre-commit-run --color=always --show-diff-on-failure
 
+  # Checks for duplicate version of package
+  cargo-vendor:
+    name: Cargo Vendor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@19eac09b398e3d0c747adc7921926a6d802df4da # v0.8.8
+        with:
+          activate-environment: true
+      - name: Test cargo vendor
+        run: cargo vendor --locked
+
   unit-tests:
     name: test
     timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ Temporary Items
 # will have compiled files and executables
 debug/
 target/
+/vendor
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,7 +3699,7 @@ dependencies = [
  "serde",
  "unicode-width 0.2.0",
  "unscanny",
- "version-ranges 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -3721,7 +3721,7 @@ dependencies = [
  "unicode-width 0.2.0",
  "url",
  "urlencoding",
- "version-ranges 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -4085,7 +4085,7 @@ dependencies = [
  "priority-queue",
  "rustc-hash",
  "thiserror 2.0.12",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=a3b4db3abb1829ce889fb89fa6d157fef529ef7e)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -6541,7 +6541,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-version",
  "uv-warnings",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=a3b4db3abb1829ce889fb89fa6d157fef529ef7e)",
+ "version-ranges",
  "walkdir",
  "zip",
 ]
@@ -6853,7 +6853,7 @@ dependencies = [
  "uv-platform-tags",
  "uv-pypi-types",
  "uv-small-str",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=a3b4db3abb1829ce889fb89fa6d157fef529ef7e)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -7095,7 +7095,7 @@ dependencies = [
  "tracing",
  "unicode-width 0.2.0",
  "unscanny",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=a3b4db3abb1829ce889fb89fa6d157fef529ef7e)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -7118,7 +7118,7 @@ dependencies = [
  "uv-fs",
  "uv-normalize",
  "uv-pep440",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=a3b4db3abb1829ce889fb89fa6d157fef529ef7e)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -7484,15 +7484,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version-ranges"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d079415ceb2be83fc355adbadafe401307d5c309c7e6ade6638e6f9f42f42d"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "version-ranges"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,7 @@ rstest = "0.25.0"
 sha2 = "0.10.9"
 insta = "1.43.1"
 serial_test = "3.2.0"
+
+[patch.crates-io]
+# This is a temporary patch to get `cargo vendor` to work with the `uv` and pep508_rs` crates.
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "a3b4db3abb1829ce889fb89fa6d157fef529ef7e" }


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

see https://github.com/prefix-dev/pixi/issues/2839 https://github.com/prefix-dev/pixi/pull/3191

# Changes

<!-- What changes have been performed? -->

add patch to make sure we don't build version-ranges twice.

---

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/pixi_pack.md as well
