### PR TITLE
ci: Generate hashes for SLSA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
       contents: write
     if: needs.metadata.outputs.release == 'true'
     # This cannot be pinned: https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
+    # https://github.com/slsa-framework/slsa-verifier/issues/12
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.hashes.outputs.hashes }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
   hashes:
     name: Compute hashes
     needs: [metadata, build]
+    if: needs.metadata.outputs.release == 'true'
     runs-on: ubuntu-latest
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -102,6 +103,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
+    if: needs.metadata.outputs.release == 'true'
     # This cannot be pinned: https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release: ${{ github.event_name == 'push' && github.repository == 'Quantco/pixi-pack' && steps.version-metadata.outputs.changed == 'true' }}
-      optimize-build: ${{ github.event_name == 'push' }}
       version: ${{ steps.version-metadata.outputs.newVersion }}
     steps:
       - name: Checkout source code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
+    # This cannot be pinned: https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.hashes.outputs.hashes }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release: ${{ github.event_name == 'push' && github.repository == 'Quantco/pixi-pack' && steps.version-metadata.outputs.changed == 'true' }}
+      optimize-build: ${{ github.event_name == 'push' }}
       version: ${{ steps.version-metadata.outputs.newVersion }}
     steps:
       - name: Checkout source code
@@ -76,9 +77,40 @@ jobs:
           path: pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
           if-no-files-found: error
 
+  hashes:
+    name: Compute hashes
+    needs: [metadata, build]
+    runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Download artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: pixi-pack-*
+          merge-multiple: true
+      - name: Compute hashes
+        id: hash
+        run: |
+          set -exuo pipefail
+          files=$(ls pixi-pack*)
+          echo "hashes=$(sha256sum $files | base64 -w0)" >> "${GITHUB_OUTPUT}"
+
+  provenance:
+    needs: [metadata, hashes]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.hashes.outputs.hashes }}"
+      upload-assets: false
+
   release:
     name: Create Release
-    needs: [metadata, build]
+    needs: [metadata, build, provenance]
     if: needs.metadata.outputs.release == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -87,6 +119,11 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: pixi-pack-*
+          merge-multiple: true
+      - name: Download provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.provenance.outputs.provenance-name }}
           merge-multiple: true
       - name: Push v${{ needs.metadata.outputs.version }} tag
         run: |
@@ -98,4 +135,6 @@ jobs:
           generate_release_notes: true
           tag_name: v${{ needs.metadata.outputs.version }}
           draft: true
-          files: pixi-pack-*
+          files: |
+            ${{ needs.provenance.outputs.provenance-name }}
+            pixi-pack-*

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+intoto = "intoto"

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The builds that are uploaded to releases on GitHub have build provenance using [
 You can verify their provenance using:
 
 ```
-slsa-verifier verify-artifact pixi-pack-<architecture> \
+pixi exec slsa-verifier verify-artifact pixi-pack-<architecture> \
     --provenance-path multiple.intoto.jsonl \
     --source-uri github.com/quantco/pixi-pack \
     --source-branch main

--- a/README.md
+++ b/README.md
@@ -233,3 +233,17 @@ conda env create -p ./env --file environment.yml
 >
 > - Add `pip` to your `pixi.lock` file using `pixi add pip`.
 > - Configuring `conda` (or `mamba`) to not install `pip` by default by running `conda config --set add_pip_as_python_dependency false` (or by adding `add_pip_as_python_dependency: False` to your `~/.condarc`)
+
+## Build provenance
+
+The builds that are uploaded to releases on GitHub have build provenance using [slsa.dev](https://slsa.dev/).
+You can verify their provenance using:
+
+```
+slsa-verifier verify-artifact pixi-pack-<architecture> \
+    --provenance-path multiple.intoto.jsonl \
+    --source-uri github.com/quantco/pixi-pack \
+    --source-branch main
+```
+
+Due to the setup of the release pipeline, the git tag is not part of the provenance but you can instead verify the commit id.


### PR DESCRIPTION
# Motivation

This adds build provenance based on the official manual of [slsa.dev](https://slsa.dev/) so that people can verify that the archives are produced by us.

You can test it on my fork using:

```
wget https://github.com/xhochy/pixi-pack/releases/download/v0.6.12/multiple.intoto.jsonl
wget https://github.com/xhochy/pixi-pack/releases/download/v0.6.12/pixi-pack-aarch64-apple-darwin
pixi exec slsa-verifier verify-artifact pixi-pack-aarch64-apple-darwin --provenance-path multiple.intoto.jsonl --source-uri github.com/xhochy/pixi-pack --source-branch main
```

As a follow-up, I would also try to integrate https://github.com/actions/attest-build-provenance into this repository. Long-term, it probably makes sense to use only one of them.

# Changes

Integrated the `slsa-framework/slsa-github-generator` workflow into the release workflow to create and upload the attestations.

---

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/pixi_pack.md as well
