### PR TITLE
fix: Panic due to duplicate -p handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-pack"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixi-pack"
 description = "A command line tool to pack and unpack conda environments for easy sharing"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 
 # See https://doc.rust-lang.org/cargo/reference/profiles.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ enum Commands {
         /// Optional path or URL to a pixi-pack executable.
         // Ex. /path/to/pixi-pack/pixi-pack.exe
         // Ex. https://example.com/pixi-pack.exe
-        #[arg(long, short, requires = "create_executable")]
+        #[arg(long, requires = "create_executable")]
         pixi_pack_source: Option<UrlOrPath>,
 
         /// Rattler config for mirror or S3 configuration.
@@ -109,7 +109,7 @@ enum Commands {
     /// Generate shell completion script
     Completion {
         /// The shell to generate the completion script for
-        #[arg(value_enum)]
+        #[arg(short, long, value_enum)]
         shell: Shell,
     },
 }


### PR DESCRIPTION
# Motivation

```
❯ cargo run -- pack
   Compiling pixi-pack v0.6.3 (/Users/pavel/projects/pixi-pack)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.13s
     Running `target/debug/pixi-pack pack`

thread 'main' panicked at /Users/pavel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.37/src/builder/debug_asserts.rs:112:17:
Command pack: Short option names must be unique for each argument, but '-p' is in use by both 'platform' and 'pixi_pack_source'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

didn't test #156 enough

# Changes

<!-- What changes have been performed? -->

---

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/pixi_pack.md as well
