### PR TITLE
ci: Upload artifact attestation on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ jobs:
     name: Build Binary (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     needs: [metadata]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +73,12 @@ jobs:
         run: |
           cargo build --profile release --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/release/pixi-pack${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }} pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        if: needs.metadata.outputs.release == 'true'
+        with:
+          subject-path: pixi-pack-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/README.md
+++ b/README.md
@@ -270,3 +270,10 @@ pixi exec slsa-verifier verify-artifact pixi-pack-<architecture> \
 ```
 
 Due to the setup of the release pipeline, the git tag is not part of the provenance but you can instead verify the commit id.
+
+In addition to the `intoto` files, we also upload build attestations to GitHub.
+You can verify a binary using the `gh` CLI:
+
+```
+gh attestation verify --repo Quantco/pixi-pack pixi-pack-<architecture>
+```


### PR DESCRIPTION
# Motivation

As a comparison to plain SLSA attestations, I have also implemented the GitHub native workflow: https://github.com/xhochy/pixi-pack/attestations/6913616. It looks much simpler, but also adds a bit more vendor-lock-in.