### PR TITLE
feat: Use rattler_config max_concurrency constants instead of hard-coded values

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,6 @@
 [default.extend-words]
 intoto = "intoto"
+concurreny = "concurreny" # xref: https://github.com/conda/rattler/pull/1479
 
 [files]
 extend-exclude = ["pixi.lock.template"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4022,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.1"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d3f48615c8e1dc3822f3b77dd31316db550db6f1a5e031d28e951b7d542341"
+checksum = "dc568e2e76a60a05d0d6b4af165fb7a924dab8d5ae83f0fab10449d42bf864e4"
 dependencies = [
  "anyhow",
  "digest",
@@ -4063,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e52069bc9d2a185dbfc516964dee59157a9fa5d381c01e2d033f1ba78b7414"
+checksum = "f3b4f4624f4768ecfe98b9841e137962ee968207381016e14e8f85beb5154fc0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -4095,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200c867fdcf925ff8ab6043c7380abcff05887aa477317f47bcf59b169ca9e12"
+checksum = "e4d7709fb4257b764f300ddd969391bcf94e13e1e66b30b8bf35d88d369401b0"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",
@@ -4136,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbd75d4b971db9225d249d5248ab76477df0e559031b16000c833f47725eace"
+checksum = "42ecc664ebfb5dceced2959f226ad83407cbd7477512234069ddf72379cb5536"
 dependencies = [
  "console",
  "fs-err",
@@ -4171,9 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46fecda0cce38d8710c6554de258ea50e2e2007690cde987cdd2979beb32fce"
+checksum = "3314f1d171f85638e7b5edf0e5443c8d3d7474e6cfe311547244344c3706454d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4187,6 +4187,7 @@ dependencies = [
  "indicatif",
  "opendal",
  "rattler_conda_types",
+ "rattler_config",
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
@@ -4205,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6a893748db0863da4da25733c14cb4db8eed068771c118499101ac517cd8ed"
+checksum = "42071a2ffa3b3b5eedeba952875043d01690ed576fae4c463038675e52f34792"
 dependencies = [
  "chrono",
  "file_url",
@@ -4241,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016fce0bf474399bdae00b0232843c7138b1348651c8327eb7406274e9e155c0"
+checksum = "3f75f14087d48cef7cad6cecbad738b88457712dfc5c7df3d59d51cd3b9888c6"
 dependencies = [
  "chrono",
  "configparser",
@@ -4265,15 +4266,15 @@ dependencies = [
  "tracing",
  "unicode-normalization",
  "which 8.0.0",
- "windows 0.60.0",
+ "windows 0.61.3",
  "windows-registry 0.5.3",
 ]
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d144dc92c2ddaddc93a69d98e30ef3c38e18b0806541363032c65ac61fb0c746"
+checksum = "c95336cf8d49ddecba334e2dc295cf4b3aeef15face7e3da73e1158c24343296"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4301,9 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.40"
+version = "0.22.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65cbd30ef7baaf30340c5be3b6c6e2b264d1f1a211a99c94be085413ecc7c51c"
+checksum = "2315b2f241c94c74c2146ba69795279600a3315d283dd302f311e1990eae0b89"
 dependencies = [
  "bzip2 0.6.0",
  "chrono",
@@ -4353,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586051feb95cb88762f6816fba3f4d846da04e55a1b6ec018c5874958285e6a5"
+checksum = "9911c838dabe26b7e8e5d286b46ba7bce96e145fa646a1767b36ee8eeeb70ee3"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4373,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e1f160df050a121e8f7db897380ae297043ff34ec6d2f0872890df0e0671be"
+checksum = "af9e511c23b4e95270579cdf33962ea6da2d18cf7ab634f1fae36963771337db"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -7447,37 +7448,15 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
-dependencies = [
- "windows-collections 0.1.1",
- "windows-core 0.60.1",
- "windows-future 0.1.1",
- "windows-link",
- "windows-numerics 0.1.1",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections 0.2.0",
+ "windows-collections",
  "windows-core 0.61.2",
- "windows-future 0.2.1",
+ "windows-future",
  "windows-link",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
-dependencies = [
- "windows-core 0.60.1",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -7504,19 +7483,6 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.60.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings 0.3.1",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
@@ -7526,16 +7492,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
-dependencies = [
- "windows-core 0.60.1",
- "windows-link",
 ]
 
 [[package]]
@@ -7587,16 +7543,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-numerics"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005dea54e2f6499f2cee279b8f703b3cf3b5734a2d8d21867c8f44003182eeed"
-dependencies = [
- "windows-core 0.60.1",
- "windows-link",
-]
 
 [[package]]
 name = "windows-numerics"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,18 @@ clap_complete = "4.5.54"
 clap-verbosity-flag = { version = "3.0.3", features = ["tracing"] }
 futures = "0.3.31"
 indicatif = "0.17.11"
-rattler = { version = "0.34.1", default-features = false }
-rattler_config = "0.1.0"
+rattler = { version = "0.34.3", default-features = false }
+rattler_config = "0.1.1"
 rattler_digest = "1.1.3"
-rattler_conda_types = "0.35.1"
-rattler_index = "0.23.1"
-rattler_lock = "0.23.6"
-rattler_networking = { version = "0.25.1", default-features = false, features = [
+rattler_conda_types = "0.35.2"
+rattler_index = "0.24.0"
+rattler_lock = "0.23.7"
+rattler_networking = { version = "0.25.2", default-features = false, features = [
   "s3",
   "rattler_config",
 ] }
-rattler_package_streaming = { version = "0.22.40", default-features = false }
-rattler_shell = "0.23.3"
+rattler_package_streaming = { version = "0.22.41", default-features = false }
+rattler_shell = "0.24.0"
 reqwest = { version = "0.12.15", default-features = false, features = [
   "http2",
   "macos-system-configuration",

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     str::FromStr,
     sync::{Arc, LazyLock},
@@ -282,7 +283,7 @@ async fn create_prefix(
                 Ok::<RepoDataRecord, anyhow::Error>(repodata_record)
             }
         })
-        .buffer_unordered(50)
+        .buffer_unordered(rattler_config::config::concurreny::default_max_concurrent_downloads())
         .try_collect()
         .await?;
 
@@ -320,6 +321,7 @@ async fn create_activation_script(
         conda_prefix: None,
         path: None,
         path_modification_behavior: PathModificationBehavior::Prepend,
+        current_env: HashMap::new(),
     })?;
 
     let contents = result.script.contents()?;


### PR DESCRIPTION
# Motivation

Closes #180 

# Changes

Use concurrency defaults from `rattler_config` or user-provided config.

---

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/pixi_pack.md as well
