### PR TITLE
fix: Fix 404 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ environment.ps1
 
 #### Custom pixi-unpack executable path
 
-When creating a self-extracting binary, you can specify a custom path or URL to a `pixi-unpack` executable to avoid downloading it from the [default location](https://github.com/Quantco/pixi-pack/releases/download).
+When creating a self-extracting binary, you can specify a custom path or URL to a `pixi-unpack` executable to avoid downloading it from the [default location](https://github.com/Quantco/pixi-pack/releases/latest).
 
 You can provide one of the following as the `--pixi-unpack-source`:
 


### PR DESCRIPTION
# Motivation

Closes #200 

# Changes

Fix 404 in README.

---

If updating documentation:

- [x] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/pixi_pack.md as well https://github.com/prefix-dev/pixi/pull/4295
